### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/agents/developer.js
+++ b/backend/agents/developer.js
@@ -73,7 +73,13 @@ Provide your implementation below:`;
         .replace(/[<>:"|?*]/g, '_') // Replace invalid Windows characters
         .replace(/\\/g, '/'); // Normalize path separators
       
-      const fullPath = path.join(repoPath, sanitizedPath);
+      const fullPath = path.resolve(repoPath, sanitizedPath);
+      
+      // Validate that the resolved path is within the repository root
+      if (!fullPath.startsWith(repoPath)) {
+        throw new Error(`Invalid file path: ${sanitizedPath} resolves outside the repository root`);
+      }
+      
       const dirPath = path.dirname(fullPath);
       
       try {


### PR DESCRIPTION
Potential fix for [https://github.com/dustinwloring1988/open-jules-ollama/security/code-scanning/1](https://github.com/dustinwloring1988/open-jules-ollama/security/code-scanning/1)

To fix the issue, we need to validate the constructed file paths (`fullPath` and `dirPath`) to ensure they remain within a safe root directory. This can be achieved by:
1. Normalizing the paths using `path.resolve` to remove any `../` segments and resolve symbolic links.
2. Checking that the normalized paths start with the intended root directory (`repoPath`).
3. Rejecting any paths that do not meet this criterion.

The changes will be made in the `parseAndApplyChanges` method in `backend/agents/developer.js`. Specifically:
- Use `path.resolve` to normalize `fullPath`.
- Validate that `fullPath` starts with `repoPath` before proceeding with file operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
