### PR TITLE
Refine planner agent prompts to remove timeframes

### DIFF
--- a/backend/agents/planner.js
+++ b/backend/agents/planner.js
@@ -8,22 +8,24 @@ export class PlannerAgent {
     const systemPrompt = `You are a senior software engineer tasked with breaking down coding tasks into clear, actionable steps.
     
 Your role is to:
-1. Analyze the given task thoroughly
-2. Break it down into logical, sequential steps
-3. Consider technical dependencies and requirements
-4. Provide clear, implementable actions
+1. Analyze the given task thoroughly.
+2. Break it down into a logical, sequential series of technical steps. Focus on the technical requirements and the order of implementation.
+3. Consider technical dependencies and requirements for each step.
+4. Provide clear, implementable actions.
+5. Do not include any time estimates or deadlines for completing the tasks.
 
 Return your response as a structured plan with numbered steps. Be specific about what needs to be done in each step.`;
 
     const prompt = `Task: ${task}
 
-Please create a detailed implementation plan for this task. Break it down into clear, sequential steps that a developer can follow. Consider:
+Please create a detailed technical implementation plan for this task. Break it down into clear, sequential steps that a developer can follow. For each step, consider:
 - What files might need to be created or modified
-- What dependencies or libraries might be needed
+- What specific code changes are needed
+- What dependencies or libraries might be required
 - The logical order of implementation
-- Any potential challenges or considerations
+- Any potential technical challenges or considerations
 
-Provide a numbered list of specific steps to complete this task.`;
+Provide a numbered list of specific, actionable steps to complete this task.`;
 
     try {
       const response = await this.ollamaService.generateResponse(this.model, prompt, systemPrompt);


### PR DESCRIPTION
This commit updates the system and main prompts for the planner agent in `backend/agents/planner.js`.

The changes ensure that I:
- Do not include time estimates or deadlines in the generated plans.
- Focus on breaking down tasks into logical, sequential, and actionable technical steps.
- Consider technical dependencies and requirements.

The prompts were refined to be more specific about the expected output, guiding me to produce plans that are purely technical and step-by-step, without any reference to time estimations.